### PR TITLE
Support `emailPrefix` when creating a masked email

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ The `options` parameter is an object that can contain the following properties:
 - `state`: `enabled` | `disabled` | `pending` ( Defaults to `enabled` )
 - `forDomain`: string ( This is the domain that you want associated with this masked email )
 - `description`: string ( This is a description of the masked email )
+- `emailPrefix`: string ( If supplied, the masked email will start with the given prefix )
 
 You can optionally pass in a `state` to set the initial state of the masked email. The default state is `enabled`.
 
@@ -146,8 +147,11 @@ newMaskedEmail = await createEmail(session, { state: 'disabled' });
 // Create a new masked email with a description
 newMaskedEmail = await createEmail(session, { description: 'My new masked email' });
 
+// Create a new masked email that starts with a given prefix
+newMaskedEmail = await createEmail(session, { emailPrefix: 'myprefix' });
+
 // Create a new masked email with all options present
-newMaskedEmail = await createEmail(session, { forDomain: 'example.com', state: 'enabled', description: 'My new masked email' });
+newMaskedEmail = await createEmail(session, { forDomain: 'example.com', state: 'enabled', description: 'My new masked email', emailPrefix: 'myprefix' });
 ```
 
 ## Updating a Masked Email

--- a/src/__tests__/create.test.ts
+++ b/src/__tests__/create.test.ts
@@ -7,7 +7,7 @@ import {
 import { InvalidArgumentError } from '../error/invalidArgumentError';
 import { createEmail } from '../lib/create';
 import { JmapRequest } from '../types/jmap';
-import { Options } from '../types/options';
+import { CreateOptions } from '../types/options';
 import { buildHeaders, parseSession } from '../util/sessionUtil';
 
 jest.mock('../util/sessionUtil');
@@ -46,7 +46,7 @@ describe('create', () => {
   });
 
   it('should createEmail a new masked email address enabled by default', async () => {
-    const options: Options = {};
+    const options: CreateOptions = {};
 
     const expectedRequest: JmapRequest = {
       using: [JMAP.CORE, MASKED_EMAIL_CAPABILITY],
@@ -105,7 +105,7 @@ describe('create', () => {
   });
 
   it('should reject with an Error when Axios receives an error response', async () => {
-    const options: Options = {};
+    const options: CreateOptions = {};
     const errorResponse = {
       status: 500,
       statusText: 'Internal Server Error',
@@ -122,7 +122,7 @@ describe('create', () => {
   });
 
   it('should reject with an Error when Axios makes a request but receives no response', async () => {
-    const options: Options = {};
+    const options: CreateOptions = {};
 
     const errorMessage = 'Network Error';
 
@@ -137,7 +137,7 @@ describe('create', () => {
   });
 
   it('should reject with an Error when another error occurs during the request', async () => {
-    const options: Options = {};
+    const options: CreateOptions = {};
 
     const errorMessage = 'Unexpected Error';
 

--- a/src/lib/create.ts
+++ b/src/lib/create.ts
@@ -10,7 +10,7 @@ import {
 import { InvalidArgumentError } from '../error/invalidArgumentError';
 import { JmapRequest, JmapSetResponse } from '../types/jmap';
 import { MaskedEmail, MaskedEmailState } from '../types/maskedEmail';
-import { Options } from '../types/options';
+import { CreateOptions } from '../types/options';
 import { ACTIONS, handleAxiosError } from '../util/errorUtil';
 import { buildHeaders, parseSession } from '../util/sessionUtil';
 
@@ -19,12 +19,12 @@ const DEFAULT_MASKED_EMAIL_STATE: MaskedEmailState = 'enabled';
 /**
  * Creates a new masked email address
  * @param session - The session object
- * @param options - The {@link Options} for creating the masked email
+ * @param options - The {@link CreateOptions|options} for creating the masked email
  * @throws {@link InvalidArgumentError} if no session is provided
  */
 export const createEmail = async (
   session: any,
-  options: Options = {}
+  options: CreateOptions = {}
 ): Promise<MaskedEmail> => {
   if (!session) {
     return Promise.reject(new InvalidArgumentError('No session provided'));

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -15,3 +15,8 @@ export interface Options {
    * */
   state?: MaskedEmailState;
 }
+
+export interface CreateOptions extends Options {
+  /** If supplied, the server-assigned email will start with the given prefix. */
+  emailPrefix?: string;
+}


### PR DESCRIPTION
Adds `emailPrefix` option when creating a masked email.

Fixes #91.